### PR TITLE
Unitary tests of mesh.get_mesh_data_from_vtk

### DIFF
--- a/test_files/test_mesh_get_mesh_data_from_vtk.py
+++ b/test_files/test_mesh_get_mesh_data_from_vtk.py
@@ -1,36 +1,47 @@
 # Unitary tests of mesh.get_mesh_data_from_vtk()
-# HowTo: In Blender/Scripting workspace, use 'Text > Open' to read this script, then 'Text > Run Script' to execute it
+# HowTo: In Blender/Scripting workspace, use "Text > Open" to read this script, then "Text > Run Script" to execute it
 
 import importlib
 import sys
+import inspect
 import traceback
+import numpy as np
 import pyvista as pv
 
 # Reload modified python scripts during development and testing
 #   see: https://blender.stackexchange.com/questions/28504/blender-ignores-changes-to-python-scripts
 #   see: https://docs.python.org/3/library/importlib.html#importlib.reload
-current_package_prefix = 'blender-vtk-importer-exporter-main'
+current_package_prefix = "blender-vtk-importer-exporter-main"
 for name, module in sys.modules.copy().items():
     if name.startswith(current_package_prefix):
         print(f"Reloading {name}")
         importlib.reload(module)
-mesh = importlib.import_module(current_package_prefix+'.mesh')
+mesh = importlib.import_module(current_package_prefix+".mesh")
 
-print()
-
-# UnstructuredGrid / single triangle without attributes
-print('TEST: UnstructuredGrid / single triangle without attributes')
-points = [[0.0, 0.0, 0.0],
-          [1.0, 0.0, 0.0],
-          [0.0, 1.0, 0.0]]
-cells = [[3, 0, 1, 2]]
-celltypes = [[pv.CellType.TRIANGLE]]
-vtk_data = pv.UnstructuredGrid(cells, celltypes, points)
-# print(vtk_data)
-try:
-    vertices, edges, faces = mesh.get_mesh_data_from_vtk(vtk_data)
-except:
-    print('..... FAILED')
-    print(traceback.format_exc())
-else:
-    print('..... PASS')
+# Wrapper
+def test_get_mesh_data_from_vtk(vtk_data):
+    print("TEST: " + inspect.currentframe().f_back.f_code.co_name)
+    try:
+        vertices, edges, faces = mesh.get_mesh_data_from_vtk(vtk_data)
+    except:
+        print("..... FAILED")
+        print(traceback.format_exc())
+    else:
+        print("..... PASS")
+        
+# Unstructured grid with a single triangle
+def test_UnstructuredGrid_one_triangle():
+    points = np.asarray([[0.0, 0.0, 0.0],
+                         [1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0]])
+    cells = np.asarray([3, 0, 1, 2])
+    celltypes = [pv.CellType.TRIANGLE]
+    vtk_data = pv.UnstructuredGrid(cells, celltypes, points)
+    test_get_mesh_data_from_vtk(vtk_data)
+        
+def main():
+    print()
+    test_UnstructuredGrid_one_triangle()
+    
+if __name__ == "__main__":
+    main()

--- a/test_files/test_mesh_get_mesh_data_from_vtk.py
+++ b/test_files/test_mesh_get_mesh_data_from_vtk.py
@@ -1,0 +1,36 @@
+# Unitary tests of mesh.get_mesh_data_from_vtk()
+# HowTo: In Blender/Scripting workspace, use 'Text > Open' to read this script, then 'Text > Run Script' to execute it
+
+import importlib
+import sys
+import traceback
+import pyvista as pv
+
+# Reload modified python scripts during development and testing
+#   see: https://blender.stackexchange.com/questions/28504/blender-ignores-changes-to-python-scripts
+#   see: https://docs.python.org/3/library/importlib.html#importlib.reload
+current_package_prefix = 'blender-vtk-importer-exporter-main'
+for name, module in sys.modules.copy().items():
+    if name.startswith(current_package_prefix):
+        print(f"Reloading {name}")
+        importlib.reload(module)
+mesh = importlib.import_module(current_package_prefix+'.mesh')
+
+print()
+
+# UnstructuredGrid / single triangle without attributes
+print('TEST: UnstructuredGrid / single triangle without attributes')
+points = [[0.0, 0.0, 0.0],
+          [1.0, 0.0, 0.0],
+          [0.0, 1.0, 0.0]]
+cells = [[3, 0, 1, 2]]
+celltypes = [[pv.CellType.TRIANGLE]]
+vtk_data = pv.UnstructuredGrid(cells, celltypes, points)
+# print(vtk_data)
+try:
+    vertices, edges, faces = mesh.get_mesh_data_from_vtk(vtk_data)
+except:
+    print('..... FAILED')
+    print(traceback.format_exc())
+else:
+    print('..... PASS')


### PR DESCRIPTION
I am trying to import a VTU file written with Paraview 6.1.0 in Blender 4.2.23 LTS.
Import fails with message

>   File "$HOME/.config/blender/4.2/scripts/addons/blender-vtk-importer-exporter-main/mesh.py", line 59, in get_mesh_data_from_vtk
    faces += cells
ValueError: operands could not be broadcast together with shapes (0,) (19,4) 

Used versions are:

- python: 3.11.7
- numpy: 2.4.6
- pyvista: 0.48.4
- vtk: 9.6.2

To trace the error, and to validate it is not dependent of the imported file, I ran a test with a single triangle. The proposed script "test_files/test_mesh_get_mesh_data_from_vtk.py" is implementing this test. The output is reporting the same error:

> TEST: test_UnstructuredGrid_one_triangle
..... FAILED
Traceback (most recent call last):
  File "/test_mesh_get_mesh_data_from_vtk.py", line 25, in test_get_mesh_data_from_vtk
  File "$HOME/.config/blender/4.2/scripts/addons/blender-vtk-importer-exporter-main/mesh.py", line 59, in get_mesh_data_from_vtk
    faces += cells
ValueError: operands could not be broadcast together with shapes (0,) (1,3) 

This branch is proposed to share the test, without modification of the mesh.py file.

_Side note: I forked an other branch to propose a correction (in short, just replace "cells" with "cells.tolist()")_
