### PR TITLE
Manage sets of cells as list instead of nparray

### DIFF
--- a/mesh.py
+++ b/mesh.py
@@ -51,12 +51,11 @@ def get_mesh_data_from_vtk(vtk_data: VTK_data):
         faces = np.reshape(vtk_data.faces, (vtk_data.n_cells, 4))[:, 1:]
 
     if isinstance(vtk_data, pv.UnstructuredGrid):
-        faces = []
         for cell_type, cells in vtk_data.cells_dict.items():
             if cell_type == pv.CellType.LINE.value:
-                edges = cells
+                edges += cells.tolist()
             elif pv.CellType.TRIANGLE.value <= cell_type <= pv.CellType.QUAD.value:
-                faces += cells
+                faces += cells.tolist()
             else:
                 warnings.warn(f"Unsupported cell type: {cell_type} yet.", stacklevel=2)
 


### PR DESCRIPTION
In get_mesh_data_from_vtk() called with a pyvista.UnstructuredGrid as input, the line 59 is throwing an error:

>   File "$HOME/.config/blender/4.2/scripts/addons/blender-vtk-importer-exporter-main/mesh.py", line 59, in get_mesh_data_from_vtk
    faces += cells
ValueError: operands could not be broadcast together with shapes (0,) (1,3) 

Used versions are:

- python: 3.11.7
- numpy: 2.4.6
- pyvista: 0.48.4
- vtk: 9.6.2

The issue seems to be the concatenation of a list ("faces") with a numpy.ndarray ("cells").
This branch proposes to use the "tolist()" function to recast the numpy.ndarray into a list.

_Comments about other modifications:_

- line 54: "faces" is already initialized empty line 46. This redundant initialization is deleted.
- line 57: even if it is likely that there is only one set of "LINE" cells, the "+=" operator is used instead of "=" to preserve the symmetry between the treatment of faces and edges.