### PR TITLE
Unit tests for the function attributes.initialize_material_attributes()

### DIFF
--- a/tests/conftest_fixtures.py
+++ b/tests/conftest_fixtures.py
@@ -3,12 +3,44 @@
 
 import numpy as np
 import pyvista as pv
+from vtk import vtkDataSetAttributes as vtkAttributeTypes
 
 import pytest
 
+from conftest_utilities import *
+
+
+# Scalar, vector and tensor fields with strictly ordered values
+#   Examples with integers and size=3:
+#   scalars: [ 1,   vectors: [[ 1,  2,  3],   tcoords: [[ 8,  9],
+#             11,             [11, 12, 13],             [18, 19],
+#             21]             [21, 22, 23]]             [28, 29]]
+#   tensors: [[ 1,  2,  3,  4,  5,  6,  7,  8,  9],
+#             [11, 12, 13, 14, 15, 16, 17, 18, 19],
+#             [21, 22, 23, 24, 25, 26, 27, 28, 29]]
+@pytest.fixture(scope="session")
+def manufactured_fields(size=5): # size: largest number of cells or points
+    # Table [t(i,j)] such that t(i,j) = j + 10*i
+    #   with i index of line and j index of column
+    #   i and j start at 0
+    int_indices = np.arange(size*10).reshape((size,-1))
+    
+    # List of (name, type, array)
+    fields = [
+        ("int_scalars", vtkAttributeTypes.SCALARS, int_indices[:,1]  ),
+        ("int_vectors", vtkAttributeTypes.VECTORS, int_indices[:,1:4]),
+        ("int_tensors", vtkAttributeTypes.TENSORS, int_indices[:,1:] ),
+        ("flt_scalars", vtkAttributeTypes.SCALARS, int_indices[:,0]   + 0.5),
+        ("flt_vectors", vtkAttributeTypes.VECTORS, int_indices[:,0:3] + 0.5),
+        ("flt_normals", vtkAttributeTypes.NORMALS, int_indices[:,3:6] + 0.5),
+        ("flt_tcoords", vtkAttributeTypes.TCOORDS, int_indices[:,8:]  + 0.5),
+        ("flt_tensors", vtkAttributeTypes.TENSORS, int_indices[:,1:]  + 0.5)
+    ]
+    return fields
+    
 
 @pytest.fixture(scope="session")
-def pvUG_three_segments():
+def pvUG_three_segments(manufactured_fields):
     points = np.asarray(
         [[0.0, 0.0, 0.0],
          [1.0, 0.0, 0.0],
@@ -21,11 +53,12 @@ def pvUG_three_segments():
     )
     celltypes = np.full((len(cells)//3), pv.CellType.LINE)
     dataset = pv.UnstructuredGrid(cells, celltypes, points)
+    set_attributes(dataset, manufactured_fields)
     return dataset
     
 
 @pytest.fixture(scope="session")
-def pvUG_one_triangle():
+def pvUG_one_triangle(manufactured_fields):
     points = np.asarray(
         [[0.0, 0.0, 0.0],
          [1.0, 0.0, 0.0],
@@ -34,12 +67,14 @@ def pvUG_one_triangle():
     cells = np.asarray([3, 0, 1, 2])
     celltypes = [pv.CellType.TRIANGLE]
     dataset = pv.UnstructuredGrid(cells, celltypes, points)
+    set_attributes(dataset, manufactured_fields)
     return dataset
     
 
 @pytest.fixture(scope="session")
-def pvPD_one_point():
+def pvPD_one_point(manufactured_fields):
     points = np.asarray([1.0, 2.0, 3.0])
     dataset = pv.PolyData(points)
+    set_attributes(dataset, manufactured_fields)
     return dataset
     

--- a/tests/conftest_fixtures.py
+++ b/tests/conftest_fixtures.py
@@ -20,9 +20,9 @@ def pvUG_three_segments():
          2, 2, 0]
     )
     celltypes = np.full((len(cells)//3), pv.CellType.LINE)
-    vtk_data = pv.UnstructuredGrid(cells, celltypes, points)
-    return vtk_data
-
+    dataset = pv.UnstructuredGrid(cells, celltypes, points)
+    return dataset
+    
 
 @pytest.fixture(scope="session")
 def pvUG_one_triangle():
@@ -33,13 +33,13 @@ def pvUG_one_triangle():
     )
     cells = np.asarray([3, 0, 1, 2])
     celltypes = [pv.CellType.TRIANGLE]
-    vtk_data = pv.UnstructuredGrid(cells, celltypes, points)
-    return vtk_data
-
+    dataset = pv.UnstructuredGrid(cells, celltypes, points)
+    return dataset
+    
 
 @pytest.fixture(scope="session")
 def pvPD_one_point():
     points = np.asarray([1.0, 2.0, 3.0])
-    vtk_data = pv.PolyData(points)
-    return vtk_data
+    dataset = pv.PolyData(points)
+    return dataset
     

--- a/tests/conftest_hooks.py
+++ b/tests/conftest_hooks.py
@@ -15,6 +15,7 @@ ordered_list_of_tests = [
     "utilities",
     "mesh_get_mesh_data_from_vtk",
     "mesh_vtk_to_mesh",
+    "attributes_initialize_material_attributes",
     "--nomatch--" # Always last entry, do not delete
 ]
 

--- a/tests/conftest_utilities.py
+++ b/tests/conftest_utilities.py
@@ -1,0 +1,40 @@
+# Functions shared by fixtures
+
+from vtk import vtkDataSetAttributes as vtkAttributeTypes
+
+
+# Add attributes to a DataSet
+#   See https://docs.pyvista.org/api/core/_autosummary/pyvista.dataset
+#       https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetattributes
+def set_attributes(dataset, fields):
+    for data, suffix, scale in (
+        (dataset.cell_data,  "_cell", -1),  # Cell values are set negative
+        (dataset.point_data, "_point", 1)): # Point values are set positive
+        
+        n = data.valid_array_len
+        for f_name, f_type, f_array in fields:
+            f_data = f_array[:n] * scale
+            match f_type:
+                case vtkAttributeTypes.NORMALS:
+                    data.active_normals = f_data
+                case vtkAttributeTypes.TCOORDS:
+                    data.active_texture_coordinates = f_data
+                case _:
+                    f_name += suffix
+                    data.set_array(f_data, f_name)
+                    match f_type:
+                        case vtkAttributeTypes.SCALARS:
+                            dataset.active_scalars_name = f_name
+                        case vtkAttributeTypes.VECTORS:
+                            dataset.active_vectors_name = f_name
+                        case vtkAttributeTypes.TENSORS:
+                            dataset.active_tensors_name = f_name
+                        case _:
+                            msg = f"Unsupported vtkDataSetAttributes type: {f_type}."
+                            raise ValueError(msg)
+
+    # Remove irrelevant fields
+    dataset.cell_data.remove("Texture Coordinates")
+    dataset.point_data.remove("Normals")
+    return
+    

--- a/tests/conftest_utilities.py
+++ b/tests/conftest_utilities.py
@@ -33,8 +33,5 @@ def set_attributes(dataset, fields):
                             msg = f"Unsupported vtkDataSetAttributes type: {f_type}."
                             raise ValueError(msg)
 
-    # Remove irrelevant fields
-    dataset.cell_data.remove("Texture Coordinates")
-    dataset.point_data.remove("Normals")
     return
     

--- a/tests/test_attributes_initialize_material_attributes.py
+++ b/tests/test_attributes_initialize_material_attributes.py
@@ -23,28 +23,31 @@ m_mesh       = import_submodule("mesh")
     "name, data_type",
     [
         pytest.param(
-            "int_scalars",         "INT",          id="int_scalars_2_INT",           marks=pytest.mark.xfail
+            "int_scalars", "INT", id="int_scalars_2_INT",
+            marks=pytest.mark.xfail(reason="Not supported yet", strict=True),
         ),
         pytest.param(
-            "int_vectors",         "FLOAT_VECTOR", id="int_vectors_2_FLOAT_VECTOR"
+            "int_vectors", "FLOAT_VECTOR", id="int_vectors_2_FLOAT_VECTOR"
         ),
         pytest.param(
-            "int_tensors",         "FLOAT4X4",     id="int_tensors_2_FLOAT4X4",      marks=pytest.mark.xfail
+            "int_tensors", "FLOAT4X4", id="int_tensors_2_FLOAT4X4",
+            marks=pytest.mark.xfail(reason="Not supported yet", strict=True),
         ),
         pytest.param(
-            "flt_scalars",         "FLOAT",        id="float_scalars_2_FLOAT"
+            "flt_scalars", "FLOAT", id="float_scalars_2_FLOAT"
         ),
         pytest.param(
-            "flt_vectors",         "FLOAT_VECTOR", id="float_vectors_2_FLOAT_VECTOR"
+            "flt_vectors", "FLOAT_VECTOR", id="float_vectors_2_FLOAT_VECTOR"
         ),
         pytest.param(
-            "Normals",             "FLOAT_VECTOR", id="Normals_2_FLOAT_VECTOR"
+            "Normals", "FLOAT_VECTOR", id="Normals_2_FLOAT_VECTOR"
         ),
         pytest.param(
-            "Texture Coordinates", "FLOAT2",       id="Texture_Coordinates_2_FLOAT2"
+            "Texture Coordinates", "FLOAT2", id="Texture_Coordinates_2_FLOAT2"
         ),
         pytest.param(
-            "flt_tensors",         "FLOAT4X4",     id="float_tensors_2_FLOAT4X4",    marks=pytest.mark.xfail
+            "flt_tensors", "FLOAT4X4", id="float_tensors_2_FLOAT4X4",
+            marks=pytest.mark.xfail(reason="Not supported yet", strict=True),
         ),
     ]
 )

--- a/tests/test_attributes_initialize_material_attributes.py
+++ b/tests/test_attributes_initialize_material_attributes.py
@@ -111,8 +111,14 @@ class TestClass:
             #     https://docs.blender.org/api/current/bpy.types.FloatAttributeValue.html
             #     https://docs.blender.org/api/current/bpy.types.IntAttributeValue.html
             property_name = "value"
-        b_values = np.zeros_like(t_values) # To store the values returned by Blender
+        if data_type == "FLOAT4X4":
+            expected_values = np.zeros((len(t_values), 4, 4), dtype=t_values.dtype)
+            expected_values[:, :3, :3] = t_values.reshape((-1, 3, 3))
+        else:
+            expected_values = t_values
+
+        b_values = np.zeros_like(expected_values)
         mesh.attributes[t_name].data.foreach_get(property_name, np.ravel(b_values))
-        assert b_values == pytest.approx(t_values)
+        assert b_values == pytest.approx(expected_values)
         
     

--- a/tests/test_attributes_initialize_material_attributes.py
+++ b/tests/test_attributes_initialize_material_attributes.py
@@ -1,0 +1,115 @@
+# Unit tests of attributes.initialize_material_attributes()
+#   TODO: Check the setup of the "mat" argument also (only the setup of the "mesh" argument is checked).
+
+import numpy as np
+
+import bpy
+
+import pytest
+
+from utilities import *
+
+
+m_attributes = import_submodule("attributes")
+m_mesh       = import_submodule("mesh")
+
+
+# Parametrization of the type of data stored in attribute
+#   name:      Name of a manufactured field, based on vtkDataSetAttributes
+#              see conftest_fixtures.manufactured_fields()
+#   data_type: Type of data manipulated by Blender
+#              see https://docs.blender.org/api/current/bpy_types_enum_items/attribute_type_items.html
+@pytest.mark.parametrize(
+    "name, data_type",
+    [
+        pytest.param(
+            "int_scalars",         "INT",          id="int_scalars_2_INT",           marks=pytest.mark.xfail
+        ),
+        pytest.param(
+            "int_vectors",         "FLOAT_VECTOR", id="int_vectors_2_FLOAT_VECTOR"
+        ),
+        pytest.param(
+            "int_tensors",         "FLOAT4X4",     id="int_tensors_2_FLOAT4X4",      marks=pytest.mark.xfail
+        ),
+        pytest.param(
+            "flt_scalars",         "FLOAT",        id="float_scalars_2_FLOAT"
+        ),
+        pytest.param(
+            "flt_vectors",         "FLOAT_VECTOR", id="float_vectors_2_FLOAT_VECTOR"
+        ),
+        pytest.param(
+            "Normals",             "FLOAT_VECTOR", id="Normals_2_FLOAT_VECTOR"
+        ),
+        pytest.param(
+            "Texture Coordinates", "FLOAT2",       id="Texture_Coordinates_2_FLOAT2"
+        ),
+        pytest.param(
+            "flt_tensors",         "FLOAT4X4",     id="float_tensors_2_FLOAT4X4",    marks=pytest.mark.xfail
+        ),
+    ]
+)
+
+# Parametrization of the domain of an attribute
+#   t_domain: Name of domain manipulated by PyVista
+#             see https://docs.pyvista.org/api/core/_autosummary/pyvista.dataset
+#   b_domain: Name of domain manipulated by Blender
+#             see https://docs.blender.org/api/current/bpy_types_enum_items/attribute_domain_items.html
+#   suffix:   Suffix of the name of a manufactured field, based on PyVista
+#             see conftest_utilities.set_attributes()
+@pytest.mark.parametrize(
+    "t_domain, b_domain, suffix",
+    [
+        pytest.param(
+            "point_data", "POINT", "_point", id="point_data_2_POINT"
+        ),
+        pytest.param(
+            "cell_data",  "FACE",  "_cell",  id="cell_data_2_FACE"
+        ),
+    ]
+)
+
+class TestClass:
+    
+    def test_domain_type(
+        self,
+        pvUG_one_triangle, # PyVista DataSet with attributes
+        t_domain, b_domain, suffix, # Domain of the attribute
+        name, data_type # Type of data stored in attribute 
+    ):
+        # Mesh and Material setup
+        mesh_name = unique_mesh_name()
+        mesh = m_mesh.vtk_to_mesh(pvUG_one_triangle, mesh_name)
+        mat = bpy.data.materials.new(name=f"{mesh_name}_attributes")
+        mat["attributes"] = {}
+        
+        # Collect of test data
+        t_name = name
+        if name not in ("Texture Coordinates", "Normals"):
+            t_name += suffix
+        t_data = getattr(pvUG_one_triangle, t_domain)
+        if t_data.get(t_name) is None:
+            pytest.skip("Irrelevant attribute")
+        t_values = t_data[t_name]
+        
+        m_attributes.initialize_material_attributes(t_name, t_values, mesh, mat, b_domain)
+        
+        # Test if the attribute is set correctly
+        assert mesh.attributes.find(t_name)      != -1
+        assert mesh.attributes[t_name].data_type == data_type
+        assert mesh.attributes[t_name].domain    == b_domain
+        
+        # Test if the values are set correctly
+        if data_type in ("FLOAT2", "FLOAT_VECTOR"):
+            # See https://docs.blender.org/api/current/bpy.types.Float2AttributeValue.html
+            #     https://docs.blender.org/api/current/bpy.types.FloatVectorAttributeValue.html
+            property_name = "vector"
+        else:
+            # See https://docs.blender.org/api/current/bpy.types.Float4x4AttributeValue.html
+            #     https://docs.blender.org/api/current/bpy.types.FloatAttributeValue.html
+            #     https://docs.blender.org/api/current/bpy.types.IntAttributeValue.html
+            property_name = "value"
+        b_values = np.zeros_like(t_values) # To store the values returned by Blender
+        mesh.attributes[t_name].data.foreach_get(property_name, np.ravel(b_values))
+        assert b_values == pytest.approx(t_values)
+        
+    

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -38,7 +38,7 @@ def reload_modules(verbose=False):
     module_name, module_path = get_current_module()
     count = 0
     for name, module in sys.modules.copy().items():
-        if name.startswith((module_name, "utilities", "test_")):
+        if name.startswith((module_name, "utilities", "conftest_", "test_")):
             if verbose:
                 print(f"Reloading {name}")
             importlib.reload(module)


### PR DESCRIPTION
This is a proposal to parametrize the unit tests of functions dealing with the type of data stored in an attribute, and with the domain into which this attribute is defined. It has to do with the mapping between PyVista and Blender of the storage of an attribute.
This is a preliminary implementation of unit tests. Not all the outcomes of initialize_material_attributes() are checked. Only those related to the mesh are compared.
Tests of data types "int" and "tensor" are included, even if the current implementation is not supporting them. Those tests are expected to fail, and are thus marked as "xfail".